### PR TITLE
feat: add Window class and configure CMake for SFML 3.0.2

### DIFF
--- a/DataStructureVisualizer/CMakeLists.txt
+++ b/DataStructureVisualizer/CMakeLists.txt
@@ -24,4 +24,21 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/in
 # TODO FOR LATER: 
 # When your team finalizes Raylib or SFML, you will use `find_package`
 # and `target_link_libraries` right here to connect the graphics!
+include(FetchContent)
+
+FetchContent_Declare(
+    SFML
+    GIT_REPOSITORY https://github.com/SFML/SFML.git
+    GIT_TAG        3.0.2
+)
+
+FetchContent_MakeAvailable(SFML)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE 
+    SFML::Graphics 
+    SFML::Window 
+    SFML::System 
+    SFML::Audio 
+    SFML::Network
+)
 # =========================================================================

--- a/DataStructureVisualizer/include/View/Window.h
+++ b/DataStructureVisualizer/include/View/Window.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <iostream>
+#include <optional>
+class Window{
+    private:
+    sf::RenderWindow RenderWindow;
+    public:
+    Window();//Initializes the window with a size, title, and sets the framerate limit.
+    void HandleEvent();//Polls for events (like closing the window).
+    void clear();//Clears the window screen with a specific color.
+    void display();//Displays what has been rendered to the window.
+    bool IsOpen() const;//Checks if the window is currently open.
+};

--- a/DataStructureVisualizer/src/View/Window.cpp
+++ b/DataStructureVisualizer/src/View/Window.cpp
@@ -1,0 +1,20 @@
+#include "view/Window.h"
+Window::Window() :RenderWindow(sf::VideoMode({1280,720}),"Data Structure Visualization",sf::Style::Default){
+RenderWindow.setFramerateLimit(60);
+}
+void Window::HandleEvent(){
+    while(const std::optional<sf::Event> a=RenderWindow.pollEvent()){
+        if(a->is<sf::Event::Closed>()){
+            RenderWindow.close();
+        }
+    }
+}
+void Window::clear(){
+    RenderWindow.clear(sf::Color({40,44,52}));
+}
+void Window::display(){
+    RenderWindow.display();
+}
+bool Window::IsOpen() const{
+    return RenderWindow.isOpen();
+}


### PR DESCRIPTION
- build: Configured FetchContent in CMakeLists.txt to automatically fetch and link SFML 3.0.2.
- feat: Implemented the Window class to encapsulate SFML's render window and handle basic window events.